### PR TITLE
closes #24: setup travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+dist: 'trusty'
+
+language: node_js
+node_js:
+  - "7"
+
+cache:
+  directories:
+    - $HOME/.npm
+    - node_modules
+
+install:
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: 'trusty'
 
 language: node_js
 node_js:
-  - "7"
+  - "stable"
 
 cache:
   directories:
@@ -12,3 +12,7 @@ cache:
 
 install:
   - npm install
+  - cd client && npm install && cd ..
+
+script:
+  - npm run test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# Exoplanets
+# Planet B
+
+[![Build Status](https://travis-ci.org/itsevalieu/planetb.svg)](https://travis-ci.org/itsevalieu/planetb)
+[![Coverage Status](https://coveralls.io/repos/github/itsevalieu/planetb/badge.svg)](https://coveralls.io/github/itsevalieu/planetb)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd client && npm test"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
closes #24 

Adds travis scripts for testing react-script.
eslint & frontend unit tests are still missing.